### PR TITLE
Add an alternative for adding binaries to the PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ If you need to add the mongoDB binaries to your path you can do so by adding the
 PATH="/Applications/MongoDB.app/Contents/Resources/Vendor/mongodb:$PATH"
 ```
 
+Or using the `path_helper` alternative:
+
+```bash
+sudo mkdir -p /etc/paths.d &&
+echo /Applications/MongoDB.app/Contents/Resources/Vendor/mongodb | sudo tee /etc/paths.d/mongodbapp
+```
+
 ### Similar projects
 
 - [Redis.app](https://jpadilla.github.io/redisapp/)


### PR DESCRIPTION
Instead of modifying the `~/.bash_profile`, you can also use the `path_helper` for constructing PATH environment variable.
For more info check `man path_helper`