### PR TITLE
Fix incomplete binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ If you need to add the mongoDB binaries to your path you can do so by adding the
 
 ```bash
 # Add mongoDB.app binaries to path
-PATH="/Applications/MongoDB.app/Contents/Resources/Vendor/mongodb:$PATH"
+PATH="/Applications/MongoDB.app/Contents/Resources/Vendor/mongodb/bin:$PATH"
 ```
 
 Or using the `path_helper` alternative:
 
 ```bash
 sudo mkdir -p /etc/paths.d &&
-echo /Applications/MongoDB.app/Contents/Resources/Vendor/mongodb | sudo tee /etc/paths.d/mongodbapp
+echo /Applications/MongoDB.app/Contents/Resources/Vendor/mongodb/bin | sudo tee /etc/paths.d/mongodbapp
 ```
 
 ### Similar projects


### PR DESCRIPTION
- Added `bin` directory to the mongoapp binary paths in the README.md

Closes #15 