### PR TITLE
fix invalid menu: open mongo in 6.0.0

### DIFF
--- a/MongoDB/AppDelegate.swift
+++ b/MongoDB/AppDelegate.swift
@@ -97,27 +97,31 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     @objc func openMongo(_ sender: AnyObject) {
-        if let path = Bundle.main.path(forResource: "mongo", ofType: "", inDirectory: "Vendor/mongodb/bin") {
-            var source: String
-            
-            if appExists("iTerm") {
-                source = "tell application \"iTerm\" \n" +
-                            "activate \n" +
-                            "create window with default profile \n" +
-                            "tell current session of current window \n" +
-                                "write text \"\(path)\" \n" +
-                            "end tell \n" +
-                        "end tell"
-            } else {
-                source = "tell application \"Terminal\" \n" +
-                            "activate \n" +
-                            "do script \"\(path)\" \n" +
-                         "end tell"
-            }
+        let path = "mongosh"
+        var source: String
+        if appExists("iTerm") {
+            source = """
+                        tell application "iTerm"
+                            activate
+                                create window with default profile
+                                tell current session of current window
+                                    write text "\(path)"
+                            end tell
+                        end tell
+                        """
+        } else {
+            source = """
+                        tell application "Terminal"
+                            activate
+                            do script "\(path)"
+                        end tell
+                        """
+        }
 
-            if let script = NSAppleScript(source: source) {
-                script.executeAndReturnError(nil)
-            }
+        if let script = NSAppleScript(source: source) {
+            var error: NSDictionary?
+            script.executeAndReturnError(&error)
+            print(error ?? "success launch mongosh")
         }
     }
     

--- a/MongoDB/Info.plist
+++ b/MongoDB/Info.plist
@@ -36,6 +36,8 @@
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>
 	<string>https://gcollazo.github.io/mongodbapp/appcast.xml</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>use iTerm/Terminal to open mongsh</string>
 	<key>SUScheduledCheckInterval</key>
 	<integer>86400</integer>
 </dict>

--- a/MongoDB/MongoDB.entitlements
+++ b/MongoDB/MongoDB.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
Since mongo 6.0.0 removed mongosh, the menu option 'open mongo' became invalid. This pull request change the action when you click 'open mongo', which require that you should install mongosh separately and add it to PATH. The 'open mongo' option will try to invoke `mongosh` command in Terminal for you.